### PR TITLE
Representations now use molecule class.

### DIFF
--- a/chemreps/bag_of_bonds.py
+++ b/chemreps/bag_of_bonds.py
@@ -10,9 +10,7 @@ import glob
 from math import sqrt
 import numpy as np
 from itertools import chain
-import sys
-sys.path.append("./utils")
-from molecule import Molecule
+from utils.molecule import Molecule
 
 
 def bag_maker(dataset):

--- a/chemreps/coulomb_matrix.py
+++ b/chemreps/coulomb_matrix.py
@@ -7,18 +7,17 @@ Author: Dakota Folmsbee
 
 from math import sqrt
 import numpy as np
-
-# nuclear charges
-nuc = {'H': 1, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 'F': 9,
-       'P': 15, 'S': 16, 'Cl': 17, 'Se': 34, 'Br': 35, 'I': 53}
+import sys
+sys.path.append("./utils")
+from molecule import Molecule
 
 
 def coulomb_matrix(mol_file, size=29):
     '''
     Paramters
     ---------
-    mol_file: file
-        molecule file for reading in coordinates
+    mol_file: string
+        molecule filename for reading in coordinates
     size: int
         size of CM matrix
 
@@ -27,87 +26,33 @@ def coulomb_matrix(mol_file, size=29):
     mat: triangle matrix
         trianle CM matrix
     '''
-    # read in file
-    file = open(mol_file, 'r')
-    filetype = mol_file.split('.')[1]
-
-    doc = []
-    for line in file:
-        doc.append(line)
-
-    if filetype == 'xyz':
-        # read number of atoms
-        natoms = int(doc[0].split()[0])
-        if natoms > size:
-            raise Exception(
-                'Molecule has {} atoms. Increase matrix size.'.format(natoms))
-
-        # parse coordinates
-        coords = []
-        for i in range(natoms):
-            a_coords = doc[i + 2].split()[0:4]
-            coords.append(a_coords)
-
-        # build CM matrix
-        mat = np.zeros((size, size))
-        for i in range(natoms):
-            for j in range(natoms):
-                z1 = nuc[coords[i][0]]
-                z2 = nuc[coords[j][0]]
-                if i == j:
-                    zij1 = 0.5 * z1 ** 2.4
-                    mat[i, i] = zij1
-
-                elif i < j:
-                    # rij = sqrt((xi - xj)^2 + (yi - yj)^2 + (zi - zj)^2)
-                    x = float(coords[i][1]) - float(coords[j][1])
-                    y = float(coords[i][2]) - float(coords[j][2])
-                    z = float(coords[i][3]) - float(coords[j][3])
-                    rij = sqrt((x ** 2) + (y ** 2) + (z ** 2))
-                    mij = (z1 * z2) / rij
-
-                    mat[j, i] = mij
-                    mat[j, i] = mij
-
-        mat = mat[np.tril_indices(size)]
-        return mat
-
-    if filetype == 'sdf' or filetype == 'mol':
-        # read number of atoms
-        natoms = int(doc[3].split()[0])
-        if natoms > size:
-            raise Exception(
-                'Molecule has {} atoms. Increase matrix size.'.format(natoms))
-
-        # parse coordinates
-        coords = []
-        for i in range(natoms):
-            a_coords = doc[i + 4].split()[0:4]
-            coords.append(a_coords)
-
-        # build CM matrix
-        mat = np.zeros((size, size))
-        for i in range(natoms):
-            for j in range(natoms):
-                z1 = nuc[coords[i][3]]
-                z2 = nuc[coords[j][3]]
-                if i == j:
-                    zij1 = 0.5 * z1 ** 2.4
-                    mat[i, i] = zij1
-
-                elif i < j:
-                    # rij = sqrt((xi - xj)^2 + (yi - yj)^2 + (zi - zj)^2)
-                    x = float(coords[i][0]) - float(coords[j][0])
-                    y = float(coords[i][1]) - float(coords[j][1])
-                    z = float(coords[i][2]) - float(coords[j][2])
-                    rij = sqrt((x ** 2) + (y ** 2) + (z ** 2))
-                    mij = (z1 * z2) / rij
-
-                    mat[j, i] = mij
-                    mat[j, i] = mij
-
-        mat = mat[np.tril_indices(size)]
-        return mat
-
-    else:
-        raise Exception('{} file type is unsupported.'.format(filetype))
+    current_molecule = Molecule(mol_file)
+    for i in range(current_molecule.n_atom):
+        for j in range(i, current_molecule.n_atom):
+            atomi = current_molecule.sym[i]
+            atomj = current_molecule.sym[j]
+            zi = current_molecule.at_num[i]
+            zj = current_molecule.at_num[j]
+    if current_molecule.n_atom > size:
+        raise Exception(
+            'Molecule has {} atoms. Increase matrix size.'.format(n_atom))
+    # build CM matrix
+    mat = np.zeros((size, size))
+    for i in range(current_molecule.n_atom):
+        for j in range(current_molecule.n_atom):
+            zi = current_molecule.at_num[i]
+            zj = current_molecule.at_num[j]
+            if i == j:
+                zij = 0.5 * zi ** 2.4
+                mat[i, i] = zij
+            elif i < j:
+                # rij = sqrt((xi - xj)^2 + (yi - yj)^2 + (zi - zj)^2)
+                x = current_molecule.xyz[i][0] - current_molecule.xyz[j][0]
+                y = current_molecule.xyz[i][1] - current_molecule.xyz[j][1]
+                z = current_molecule.xyz[i][2] - current_molecule.xyz[j][2]
+                rij = sqrt((x ** 2) + (y ** 2) + (z ** 2))
+                mij = (zi * zj) / rij
+                mat[i, j] = mij
+                mat[j, i] = mij
+    mat = mat[np.tril_indices(size)]
+    return mat

--- a/chemreps/coulomb_matrix.py
+++ b/chemreps/coulomb_matrix.py
@@ -33,7 +33,7 @@ def coulomb_matrix(mol_file, size=29):
             zj = current_molecule.at_num[j]
     if current_molecule.n_atom > size:
         raise Exception(
-            'Molecule has {} atoms. Increase matrix size.'.format(n_atom))
+            'Molecule has {} atoms. Increase matrix size.'.format(current_molecule.n_atom))
     # build CM matrix
     mat = np.zeros((size, size))
     for i in range(current_molecule.n_atom):

--- a/chemreps/coulomb_matrix.py
+++ b/chemreps/coulomb_matrix.py
@@ -7,9 +7,7 @@ Author: Dakota Folmsbee
 
 from math import sqrt
 import numpy as np
-import sys
-sys.path.append("./utils")
-from molecule import Molecule
+from utils.molecule import Molecule
 
 
 def coulomb_matrix(mol_file, size=29):

--- a/chemreps/utils/molecule.py
+++ b/chemreps/utils/molecule.py
@@ -18,7 +18,9 @@ class Molecule:
     __nuc = {'H': 1, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 'F': 9,
              'P': 15, 'S': 16, 'Cl': 17, 'Se': 34, 'Br': 35, 'I': 53}
 
-    def __init__(self):
+    def __init__(self,fname=None):
+        if fname is not None:
+            self.import_file(fname)
         return None
 
     def sym2num(self, sym):


### PR DESCRIPTION
Molecule class need to be slightly modified to allow use to "overload" the constructor.
We can call a null constructor and just make the molecule the instantiate.
Or we can call the constructor with a filename and it will create and instatiate the molecule.

Both representations now use the molecule class. Previous the code checked if the file was
of a supported type before making the rep. This has been removed. I think that this should be
handled by the molecule class followed by a try,except,pass. I will open an issue for discussion
and we should probably discuss in person as well.