### PR TITLE
Adding precommit hooks to ensure code is formatted correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+- repo: https://github.com/pre-commit/mirrors-autopep8
+  rev: v1.4.3
+  hooks:
+  - id: autopep8
+- repo: git@github.com:pre-commit/pre-commit-hooks.git
+  rev: v2.0.0
+  hooks:
+  - id: check-added-large-files
+  - id: flake8
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
I edited the wiki to include instructions on how to set this up, but now we will get checks like this on commit: 
```
autopep8.............................................(no files to check)Skipped
Check for added large files..............................................Passed
Flake8...............................................(no files to check)Skipped
Fix requirements.txt.....................................................Passed
Trim Trailing Whitespace.................................................Passed
```