### PR TITLE
Added bagger to autodocs

### DIFF
--- a/docs/source/chemreps.rst
+++ b/docs/source/chemreps.rst
@@ -11,6 +11,14 @@ Subpackages
 Submodules
 ----------
 
+chemreps.bagger module
+----------------------
+
+.. automodule:: chemreps.bagger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 chemreps.bag\_of\_bonds module
 ------------------------------
 


### PR DESCRIPTION
Fixes the #36 issue. We will have to worry about adding new files to this and the chemreps.utils.rst file as we create them.